### PR TITLE
Fix incorrect link to docs from Apache instructions

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -28,6 +28,6 @@ subcommand:
         </p></aside>
 {{/advanced}}
 
-To learn more about how to use Certbot <a href="/about">read our documentation</a>.
+To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
 </p>
 {{> renewal}}


### PR DESCRIPTION
The "read our documentation" link in the [Getting Started section for Apache on Ubuntu Trusty](https://certbot.eff.org/#ubuntutrusty-apache) takes you to /about instead of /docs.